### PR TITLE
NowarnCompatPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ lazy val root = project
   + Ensures bintray package existence
   + Performs sonatype release steps
   + Stages through `bintrayRelease` to allow release atomicity
+* `NowarnCompatPlugin`
+  + Adds support for `@nowarn` to Scala 2.11, 2.12, and 2.13.1 via Silencer.
+  + Adds scala-collection-compat to the classpath for versions that need Silencer. Opt out by configuring `nowarnCompatAnnotationProvider`.
 
 ### Bintray Requirements
 

--- a/core/src/main/scala/sbtspiewak/NowarnCompatPlugin.scala
+++ b/core/src/main/scala/sbtspiewak/NowarnCompatPlugin.scala
@@ -32,14 +32,19 @@ object NowarnCompatPlugin extends AutoPlugin {
   override def trigger = noTrigger
   override def requires = ExplicitDepsPlugin
 
-  override def projectSettings = Seq(
+  override def globalSettings = Seq(
     nowarnCompatSilencerVersion := "1.7.0",
     nowarnCompatAnnotationProvider := Some("org.scala-lang.modules" %% "scala-collection-compat" % "2.3.0"),
+  )
+
+  override def projectSettings = Seq(
     libraryDependencies ++= {
       scalaVersion.value match {
         case FullScalaVersion(2, 13, x, _, _) if x >= 2 =>
           Seq.empty
-        case FullScalaVersion(3, _, _, _, _) =>
+        case FullScalaVersion(0, _, _, _, _) => // Old Dotties
+          Seq.empty
+        case FullScalaVersion(3, _, _, _, _) => // New Dotties
           Seq.empty
         case _ =>
           Seq(

--- a/core/src/main/scala/sbtspiewak/NowarnCompatPlugin.scala
+++ b/core/src/main/scala/sbtspiewak/NowarnCompatPlugin.scala
@@ -33,19 +33,18 @@ object NowarnCompatPlugin extends AutoPlugin {
   override def requires = ExplicitDepsPlugin
 
   override def globalSettings = Seq(
-    nowarnCompatSilencerVersion := "1.7.0",
+    nowarnCompatSilencerVersion := "1.7.1",
     nowarnCompatAnnotationProvider := Some("org.scala-lang.modules" %% "scala-collection-compat" % "2.3.0"),
   )
 
   override def projectSettings = Seq(
     libraryDependencies ++= {
       scalaVersion.value match {
-        case FullScalaVersion(2, 13, x, _, _) if x >= 2 =>
-          Seq.empty
-        case FullScalaVersion(0, _, _, _, _) => // Old Dotties
-          Seq.empty
-        case FullScalaVersion(3, _, _, _, _) => // New Dotties
-          Seq.empty
+        case FullScalaVersion(3, _, _, _, _) => Seq.empty // New Dotties
+        case FullScalaVersion(0, _, _, _, _) => Seq.empty // Old Dotties
+        case FullScalaVersion(2, 13, x, _, _) if x >= 2 => Seq.empty // Native support
+        case FullScalaVersion(2, 13, x, _, _) =>
+          sys.error(s"NowarnCompatPlugin: Unsupported Scala version: ${scalaVersion.value}. Scala 2.13 must be at least 2.13.2.")
         case _ =>
           Seq(
             compilerPlugin(("com.github.ghik" % "silencer-plugin" % nowarnCompatSilencerVersion.value).cross(CrossVersion.full)),
@@ -54,10 +53,10 @@ object NowarnCompatPlugin extends AutoPlugin {
           ) ++
           (nowarnCompatAnnotationProvider.value match {
             case Some(moduleId) =>
-              sLog.value.info(s"SilencerPlugin: ${scalaVersion.value} doesn't support @nowarn. Adding ${moduleId}.")
+              sLog.value.info(s"SilencerPlugin: Scala ${scalaVersion.value} doesn't support @nowarn. Adding ${moduleId}.")
               Seq(moduleId)
             case None =>
-              sLog.value.warn(s"SilencerPlugin: ${scalaVersion.value} doesn't support @nowarn. Project will need to supply its own scala.annotation.nowarn implementation, or set `nowarnCompatAnnotationProvider`.")
+              sLog.value.warn(s"SilencerPlugin: Scala ${scalaVersion.value} doesn't support @nowarn. Project needs to supply its own @nowarn implementation, or set `nowarnCompatAnnotationProvider`.")
               Seq.empty
           })
       }

--- a/core/src/main/scala/sbtspiewak/NowarnCompatPlugin.scala
+++ b/core/src/main/scala/sbtspiewak/NowarnCompatPlugin.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sbtspiewak
+
+import sbt._
+import sbt.Keys._
+
+import explicitdeps.ExplicitDepsPlugin, ExplicitDepsPlugin.autoImport._
+
+object NowarnCompatPlugin extends AutoPlugin {
+  object autoImport {
+    val nowarnCompatSilencerVersion = settingKey[String]("Version of the silencer compiler plugin")
+    val nowarnCompatAnnotationProvider = settingKey[Option[ModuleID]]("Module providing scala.annotation.nowarn ")
+  }
+
+  import autoImport._
+
+  override def trigger = noTrigger
+  override def requires = ExplicitDepsPlugin
+
+  override def projectSettings = Seq(
+    nowarnCompatSilencerVersion := "1.7.0",
+    nowarnCompatAnnotationProvider := Some("org.scala-lang.modules" %% "scala-collection-compat" % "2.3.0"),
+    libraryDependencies ++= {
+      scalaVersion.value match {
+        case FullScalaVersion(2, 13, x, _, _) if x >= 2 =>
+          Seq.empty
+        case FullScalaVersion(3, _, _, _, _) =>
+          Seq.empty
+        case _ =>
+          Seq(
+            compilerPlugin(("com.github.ghik" % "silencer-plugin" % nowarnCompatSilencerVersion.value).cross(CrossVersion.full)),
+            ("com.github.ghik" % "silencer-lib" % nowarnCompatSilencerVersion.value % Provided).cross(CrossVersion.full),
+            ("com.github.ghik" % "silencer-lib" % nowarnCompatSilencerVersion.value % Test).cross(CrossVersion.full)
+          ) ++
+          (nowarnCompatAnnotationProvider.value match {
+            case Some(moduleId) =>
+              sLog.value.info(s"SilencerPlugin: ${scalaVersion.value} doesn't support @nowarn. Adding ${moduleId}.")
+              Seq(moduleId)
+            case None =>
+              sLog.value.warn(s"SilencerPlugin: ${scalaVersion.value} doesn't support @nowarn. Project will need to supply its own scala.annotation.nowarn implementation, or set `nowarnCompatAnnotationProvider`.")
+              Seq.empty
+          })
+      }
+    },
+    unusedCompileDependenciesFilter -= moduleFilter("com.github.ghik", "silencer-lib"),
+  )
+}

--- a/core/src/sbt-test/sbtspiewak/nowarn/build.sbt
+++ b/core/src/sbt-test/sbtspiewak/nowarn/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / crossScalaVersions := Seq("2.11.12", "2.12.12"," 2.13.3", "0.27.0-RC1", "3.0.0-M1")
+ThisBuild / crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.3", "0.27.0-RC1", "3.0.0-M1")
 
 ThisBuild / baseVersion := "0.1"
 

--- a/core/src/sbt-test/sbtspiewak/nowarn/build.sbt
+++ b/core/src/sbt-test/sbtspiewak/nowarn/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.1", "2.13.2", "3.0.0-M1")
+ThisBuild / crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.0", "2.13.1", "2.13.2", "0.27.0-RC1", "3.0.0-M1")
 
 ThisBuild / baseVersion := "0.1"
 

--- a/core/src/sbt-test/sbtspiewak/nowarn/build.sbt
+++ b/core/src/sbt-test/sbtspiewak/nowarn/build.sbt
@@ -1,10 +1,13 @@
-ThisBuild / crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.0", "2.13.1", "2.13.2", "0.27.0-RC1", "3.0.0-M1")
+ThisBuild / crossScalaVersions := Seq("2.11.12", "2.12.12"," 2.13.3", "0.27.0-RC1", "3.0.0-M1")
 
 ThisBuild / baseVersion := "0.1"
 
 ThisBuild / publishGithubUser := "djspiewak"
 ThisBuild / publishFullName := "Daniel Spiewak"
 
-scalacOptions += "-Xfatal-warnings"
+scalacOptions ++= {
+  if (isDotty.value) Seq.empty // @nowarn compiles, but doesn't work
+  else Seq("-Xfatal-warnings")
+}
 
 enablePlugins(NowarnCompatPlugin)

--- a/core/src/sbt-test/sbtspiewak/nowarn/build.sbt
+++ b/core/src/sbt-test/sbtspiewak/nowarn/build.sbt
@@ -1,0 +1,10 @@
+ThisBuild / crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.1", "2.13.2", "3.0.0-M1")
+
+ThisBuild / baseVersion := "0.1"
+
+ThisBuild / publishGithubUser := "djspiewak"
+ThisBuild / publishFullName := "Daniel Spiewak"
+
+scalacOptions += "-Xfatal-warnings"
+
+enablePlugins(NowarnCompatPlugin)

--- a/core/src/sbt-test/sbtspiewak/nowarn/project/build.properties
+++ b/core/src/sbt-test/sbtspiewak/nowarn/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.0

--- a/core/src/sbt-test/sbtspiewak/nowarn/project/plugins.sbt
+++ b/core/src/sbt-test/sbtspiewak/nowarn/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.codecommit" % "sbt-spiewak" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/core/src/sbt-test/sbtspiewak/nowarn/project/plugins.sbt
+++ b/core/src/sbt-test/sbtspiewak/nowarn/project/plugins.sbt
@@ -1,0 +1,8 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.codecommit" % "sbt-spiewak" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}
+
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.3.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")

--- a/core/src/sbt-test/sbtspiewak/nowarn/project/plugins.sbt
+++ b/core/src/sbt-test/sbtspiewak/nowarn/project/plugins.sbt
@@ -1,8 +1,0 @@
-sys.props.get("plugin.version") match {
-  case Some(x) => addSbtPlugin("com.codecommit" % "sbt-spiewak" % x)
-  case _       => sys.error("""|The system property 'plugin.version' is not defined.
-                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-}
-
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.3.1")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")

--- a/core/src/sbt-test/sbtspiewak/nowarn/src/main/scala/Decrepitude.scala
+++ b/core/src/sbt-test/sbtspiewak/nowarn/src/main/scala/Decrepitude.scala
@@ -1,0 +1,10 @@
+import java.util.Date
+import scala.annotation.nowarn
+
+object Decrepitude {
+  @nowarn("cat=deprecation")
+  val decrepit = {
+    // Yo, we don't do this anymore
+    new Date(2020, 11, 21)
+  }
+}

--- a/core/src/sbt-test/sbtspiewak/nowarn/test
+++ b/core/src/sbt-test/sbtspiewak/nowarn/test
@@ -1,0 +1,1 @@
+> +compile


### PR DESCRIPTION
Scala >= 2.13.2 (including Dotty) use a `@nowarn` annotation.  Silencer >= 1.7.0 supports it on older Scala versions, if you bring your own `@nowarn`.  (This version is unfortunately not published for 2.13.0 or 2.13.1.)

This plugin:
- Does nothing on Scala versions that support @nowarn
- Fails on 2.13.0 and 2.13.1.
- Adds the silencer plugin and optionally a module, defaulting to scala-collection-compat, to provide the annotation.