### PR TITLE
Add better-monadic-for to Scala 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ With all of these steps out of the way, you should have some nice, reliable, CI-
 - Sane scalac settings
   + Including `-Ybackend-parallelism` where supported
 - SI-2712 fix across scala versions (dating back to 2.10)
-- kind-projector
+- kind-projector (Scala 2 only)
+- better-monadic-for (Scala 2 only)
 - `release` and `ci` command aliases
   + Ensures bintray package existence
   + Performs sonatype release steps

--- a/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
+++ b/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
@@ -236,7 +236,10 @@ object SpiewakPlugin extends AutoPlugin {
         if (isDotty.value)
           Nil
         else
-          Seq(compilerPlugin("org.typelevel" % "kind-projector" % "0.11.1" cross CrossVersion.full))
+          Seq(
+            compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
+            compilerPlugin("org.typelevel" % "kind-projector" % "0.11.1" cross CrossVersion.full),
+          )
       },
 
       // Adapted from Rob Norris' post at https://tpolecat.github.io/2014/04/11/scalac-flags.html


### PR DESCRIPTION
I use this everywhere, and I think it does no harm, if the weird `implicit0` is avoided.