### PR TITLE
Limit -Ybackend-parallelism to 16

### DIFF
--- a/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
+++ b/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
@@ -330,7 +330,7 @@ object SpiewakPlugin extends AutoPlugin {
 
       scalacOptions ++= {
         val numCPUs = java.lang.Runtime.getRuntime.availableProcessors()
-        val settings = Seq(s"-Ybackend-parallelism", numCPUs.toString)
+        val settings = Seq(s"-Ybackend-parallelism", scala.math.min(16, numCPUs).toString)
 
         scalaVersion.value match {
           case FullScalaVersion(2, 12, build, _, _) if build >= 5 =>


### PR DESCRIPTION
Limits the value of `-Ybackend-parallelism` to `16` as values greater than this result in the following error
```
[error] invalid setting for -Ybackend-parallelism must be between 1 and 16
```