### PR TITLE
Use moduleName instead of name in mimaPreviousArtifacts

### DIFF
--- a/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
+++ b/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
@@ -501,7 +501,7 @@ object SpiewakPlugin extends AutoPlugin {
       mimaPreviousArtifacts := {
         val current = version.value
         val org = organization.value
-        val n = name.value
+        val n = moduleName.value
 
         val TagBase = """^(\d+)\.(\d+).*"""r
         val TagBase(major, minor) = baseVersion.value


### PR DESCRIPTION
Because they're the same until they're not.