### PR TITLE
Move sonatype settings to ThisBuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ Check [sbt-bintray credentials](https://github.com/sbt/sbt-bintray#Credentials) 
 You will additionally need to define the following settings:
 
 ```sbt
-Global / homepage := Some(url("https://github.com/djspiewak/sbt-spiewak")),
+ThisBuild / homepage := Some(url("https://github.com/djspiewak/sbt-spiewak")),
 
-Global / scmInfo := Some(ScmInfo(url("https://github.com/djspiewak/sbt-spiewak"),
+ThisBuild / scmInfo := Some(ScmInfo(url("https://github.com/djspiewak/sbt-spiewak"),
   "git@github.com:djspiewak/sbt-spiewak.git")))
 ```
 


### PR DESCRIPTION
Ok after spending 2 days on this:
having these settings in Global works when you release from your local machine, but fails in CI with `scm url missing`. Obviously don't ask me why :)

FTR: I haven't done a final checking of publishing from my machine when they are in `ThisBuild`, nor have I tried with Bintray.

Gotta thank mpilquist for confirming he had to do the same and getting me unstuck :)


I'm probably going to PR longer instructions on how to setup your gpg key, since you need to generate a new one with no passphrase, and you won't be able to export an existing one which has a passphrase, as soon as I get some time