### PR TITLE
do not include empty tags in gitCurrentTags

### DIFF
--- a/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
+++ b/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
@@ -229,7 +229,7 @@ object SpiewakPlugin extends AutoPlugin {
       git.gitUncommittedChanges := Try("git status -s".!!.trim.length > 0).getOrElse(true),
 
       git.gitHeadCommit := Try("git rev-parse HEAD".!!.trim).toOption,
-      git.gitCurrentTags := Try("git tag --contains HEAD".!!.trim.split("\\s+").toList).toOption.toList.flatten)
+      git.gitCurrentTags := Try("git tag --contains HEAD".!!.trim.split("\\s+").toList.filter(_ != "")).toOption.toList.flatten)
 
   override def projectSettings =
     AutomateHeaderPlugin.projectSettings ++


### PR DESCRIPTION
Before (and also after) this change, we have

```
sbt:root> gitCurrentTags
[info] core / gitCurrentTags
[info] 	List()
[info] bintray / gitCurrentTags
[info] 	List()
[info] sonatype / gitCurrentTags
[info] 	List()
[info] gitCurrentTags
[info] 	List()
```

which seems to indicate that these lists are empty. Surprisingly, this is not the case, they are one-element lists containing the empty string. With this change, they are *actually* empty. This was very confusing to me! :laughing: 