### PR TITLE
Set homepage in build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ Global / organization := "com.codecommit"
 
 Global / publishGithubUser := "djspiewak"
 Global / publishFullName := "Daniel Spiewak"
+Global / homepage := Some(url("https://github.com/djspiewak/sbt-spiewak"))
 
 Global / baseVersion := "0.20"
 


### PR DESCRIPTION
This sets the homepage setting to https://github.com/djspiewak/sbt-spiewak.
It enables Scala Steward to link to this page, the GitHub release notes
and version diff in its pull requests.