### PR TITLE
Skip compatibility scalac options when not cross-building for 2.x

### DIFF
--- a/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
+++ b/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
@@ -354,7 +354,9 @@ object SpiewakPlugin extends AutoPlugin {
       },
 
       scalacOptions ++= {
-        if (isDotty.value)
+        if (isDotty.value && crossScalaVersions.value.forall(_.startsWith("3.")))
+          Seq("-Ykind-projector:underscores")
+        else if (isDotty.value)
           Seq("-language:implicitConversions", "-Ykind-projector", "-source:3.0-migration")
         else
           Seq("-language:_")


### PR DESCRIPTION
This came up when trying out the new syntax in a Scala 3-only project.

Eventually, this should probably be supported as an option for cross-builds to switch to Scala 3 syntax where the compatibility flags are added to Scala 2.x instead.