### PR TITLE
Enable MiMa for all platforms

### DIFF
--- a/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
+++ b/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
@@ -480,7 +480,7 @@ object SpiewakPlugin extends AutoPlugin {
 
           val isPre = major.toInt == 0
 
-          if (sbtPlugin.value || !crossProjectPlatform.?.value.map(_.identifier == "jvm").getOrElse(true)) {
+          if (sbtPlugin.value) {
             Set.empty
           } else {
             val tags = Try("git tag --list".!!.split("\n").map(_.trim)).getOrElse(new Array[String](0))


### PR DESCRIPTION
Now that many more typelevel projects are crossing for JS with platform-specific sources, guaranteeing bincompat is more important than ever. In case there is any doubt, there _is_ MiMa for Scala.js (as well as Native I assume):

> .sjsir files have binary compatibility guarantees similar to those of .class files. With a few exceptions related to JS interop annotations, if changes to a .class files are binary compatible, then the changes applied to the corresponding .sjsir files are also binary compatible. This allows Scala.js codebases to meaningfully use MiMa to check that they do not break their binary API.

Via https://www.scala-lang.org/2020/11/03/scalajs-for-scala-3.html.

sbt-spiewak currently disables MiMa for non-JVM platforms. I think this is the right bit to change?