### PR TITLE
Add a `sonatypeBundleReleaseIfRelevant` command

### DIFF
--- a/sonatype/src/main/scala/sbtspiewak/SpiewakSonatypePlugin.scala
+++ b/sonatype/src/main/scala/sbtspiewak/SpiewakSonatypePlugin.scala
@@ -39,12 +39,9 @@ object SpiewakSonatypePlugin extends AutoPlugin {
   private def sonatypeBundleReleaseIfRelevant: Command =
     Command.command("sonatypeBundleReleaseIfRelevant") { state =>
       val isSnap = state.getSetting(isSnapshot).getOrElse(false)
-      if (!isSnap) {
-        import sbt.complete.Parser
-        Parser.parse("sonatypeBundleRelease", state.combinedParser) match {
-          case Right(cmd) => cmd()
-          case Left(msg) => sys.error(msg)
-        }
-      } else state
+      if (!isSnap)
+        Command.process("sonatypeBundleRelease", state)
+      else
+        state
     }
 }


### PR DESCRIPTION
A re-do of #52. Thank you @armanbilge for the original PR.

I managed to publish both a `-SNAPSHOT` to the snapshot repository and

```scala
"io.vasilev" %% "discipline" % "1.4-2-8f482d7-SNAPSHOT",
"io.vasilev" %% "discipline" % "1.4-3-ee5f9c6"
```