### PR TITLE
Publish snapshots by default and add an override for hash releases

### DIFF
--- a/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
+++ b/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
@@ -247,6 +247,7 @@ object SpiewakPlugin extends AutoPlugin {
       mimaReportBinaryIssuesIfRelevant := filterTaskWhereRelevant(mimaReportBinaryIssues).value,
       publishIfRelevant := filterTaskWhereRelevant(publish).value,
       publishLocalIfRelevant := filterTaskWhereRelevant(publishLocal).value,
+      SbtGpg.autoImport.gpgWarnOnFailure := isSnapshot.value,
 
       libraryDependencies ++= {
         if (isDotty.value)

--- a/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
+++ b/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala
@@ -69,6 +69,7 @@ object SpiewakPlugin extends AutoPlugin {
     lazy val testIfRelevant = taskKey[Unit]("A wrapper around the `test` task which checks to ensure the current scalaVersion is in crossScalaVersions")
     lazy val mimaReportBinaryIssuesIfRelevant = taskKey[Unit]("A wrapper around the `test` task which checks to ensure the current scalaVersion is in crossScalaVersions")
 
+    lazy val publishSnapshotsAsHashReleases = settingKey[Boolean]("Overrides the snapshot releases and switches to stable hash releases instead")
     lazy val publishIfRelevant = taskKey[Unit]("A wrapper around the `publish` task which checks to ensure the current scalaVersion is in crossScalaVersions")
     lazy val publishLocalIfRelevant = taskKey[Unit]("A wrapper around the `publishLocal` task which checks to ensure the current scalaVersion is in crossScalaVersions")
 
@@ -180,8 +181,14 @@ object SpiewakPlugin extends AutoPlugin {
         }
       },
 
+      publishSnapshotsAsHashReleases := false,
       git.formattedShaVersion := {
-        val suffix = git.makeUncommittedSignifierSuffix(git.gitUncommittedChanges.value, git.uncommittedSignifier.value)
+        val hashOverride = publishSnapshotsAsHashReleases.value
+        val condition =
+          if (hashOverride) git.gitUncommittedChanges.value // old sbt-spiewak behavior
+          else git.gitCurrentTags.value.isEmpty || git.gitUncommittedChanges.value // default sbt-git behavior
+
+        val suffix = git.makeUncommittedSignifierSuffix(condition, git.uncommittedSignifier.value)
 
         val description = Try("git describe --tags --match v*".!!.trim).toOption
         val optDistance = description collect {
@@ -198,7 +205,10 @@ object SpiewakPlugin extends AutoPlugin {
       git.gitUncommittedChanges := Try("git status -s".!!.trim.length > 0).getOrElse(true),
 
       git.gitHeadCommit := Try("git rev-parse HEAD".!!.trim).toOption,
-      git.gitCurrentTags := Try("git tag --contains HEAD".!!.trim.split("\\s+").toList.filter(_ != "")).toOption.toList.flatten)
+      git.gitCurrentTags := Try("git tag --contains HEAD".!!.trim.split("\\s+").toList.filter(_ != "")).toOption.toList.flatten,
+
+      commands += publishHashIfRelevant
+    )
 
   override def projectSettings =
     AutomateHeaderPlugin.projectSettings ++
@@ -531,4 +541,19 @@ object SpiewakPlugin extends AutoPlugin {
       unusedCompileDependenciesFilter -=
         moduleFilter("org.scala-js", "scalajs-library*") |
         moduleFilter("org.scala-lang", "scala3-library*"))
+
+  private def publishHashIfRelevant: Command =
+    Command.command("publishHashIfRelevant") { state1 =>
+      val cross = state1.setting(crossScalaVersions)
+      val ver = state1.setting(scalaVersion)
+
+      if (cross.contains(ver)) {
+        val old = state1.setting(publishSnapshotsAsHashReleases)
+        val state2 = state1.appendWithSession(Seq(ThisBuild / publishSnapshotsAsHashReleases := true))
+        val state3 = Command.process("publishIfRelevant", state2)
+        state3.appendWithSession(Seq(ThisBuild / publishSnapshotsAsHashReleases := old))
+      } else {
+        state1
+      }
+    }
 }

--- a/core/src/sbt-test/sbtspiewak/versions/build.sbt
+++ b/core/src/sbt-test/sbtspiewak/versions/build.sbt
@@ -5,6 +5,8 @@ ThisBuild / baseVersion := "0.2"
 ThisBuild / publishGithubUser := "djspiewak"
 ThisBuild / publishFullName := "Daniel Spiewak"
 
+ThisBuild / publishSnapshotsAsHashReleases := true
+
 lazy val setup1 = taskKey[Unit]("")
 lazy val check1 = taskKey[Unit]("")
 

--- a/sonatype/src/main/scala/sbtspiewak/SpiewakSonatypePlugin.scala
+++ b/sonatype/src/main/scala/sbtspiewak/SpiewakSonatypePlugin.scala
@@ -37,11 +37,25 @@ object SpiewakSonatypePlugin extends AutoPlugin {
   )
 
   private def sonatypeBundleReleaseIfRelevant: Command =
-    Command.command("sonatypeBundleReleaseIfRelevant") { state =>
-      val isSnap = state.getSetting(isSnapshot).getOrElse(false)
+    Command.command("sonatypeBundleReleaseIfRelevant") { state1 =>
+      val isSnap = state1.getSetting(isSnapshot).getOrElse(false)
       if (!isSnap)
-        Command.process("sonatypeBundleRelease", state)
-      else
-        state
+        Command.process("sonatypeBundleRelease", state1)
+      else {
+        // Check for a published hash version.
+        val ver = state1.setting(ThisBuild / version)
+        val nonSnap = ver.replace("-SNAPSHOT", "")
+        val base = state1.setting(ThisBuild / baseDirectory)
+        val hashDirectory = base / "target" / "sonatype-staging" / nonSnap
+        if (hashDirectory.exists()) {
+          // A hash release exists. Release it.
+          val state2 = state1.appendWithSession(Seq((ThisBuild / version) := nonSnap))
+          val state3 = Command.process("sonatypeBundleRelease", state2)
+          state3.appendWithSession(Seq((ThisBuild / version) := ver))
+        } else {
+          // Do nothing.
+          state1
+        }
+      }
     }
 }

--- a/sonatype/src/main/scala/sbtspiewak/SpiewakSonatypePlugin.scala
+++ b/sonatype/src/main/scala/sbtspiewak/SpiewakSonatypePlugin.scala
@@ -39,12 +39,9 @@ object SpiewakSonatypePlugin extends AutoPlugin {
   private def sonatypeBundleReleaseIfRelevant: Command =
     Command.command("sonatypeBundleReleaseIfRelevant") { state =>
       val isSnap = state.getSetting(isSnapshot).getOrElse(false)
-      if (!isSnap) {
-        import sbt.complete.Parser
-        Parser.parse("sonatypeBundleRelease", state.combinedParser) match {
-          case Right(cmd) => cmd()
-          case Left(msg) => sys.error(msg)
-        }
-      } else state
+      if (!isSnap)
+        Command.process("sonatypeBundleRelease", state)
+      else
+        state
     }
 }


### PR DESCRIPTION
@armanbilge and I worked on this after discussing SNAPSHOT releases with other maintainers on [Discord](https://discord.com/channels/632277896739946517/839263556754472990/919701548215443466). We think this is generally desired by people.

By combining both the `hash` and the `-SNAPSHOT` suffix, we believe we can achieve a sensible middle ground where snapshots are _mutable_ but not actually _mutated_ (unless the user goes out of their way to make sure the hash matches a previous version), so this helps with the stability, maven central is not polluted (this doesn't at all affect tagged releases and they can still be done manually) and maintainers have a steady stream of stable snapshots to test stuff and look for regressions.